### PR TITLE
Added official flag names and some of my advanced flags research

### DIFF
--- a/flags.json
+++ b/flags.json
@@ -2,123 +2,123 @@
 	"version":"1.1",
 	"flags": {
 		"strModelFlags": [{
-				"name": "IS_VAN",
+				"name": "MF_IS_VAN",
 				"description": "Allows double doors for the rear doors animation."
 			},
 			{
-				"name": "IS_BUS",
+				"name": "MF_IS_BUS",
 				"description": "Uses bus animations for entry/exit."
 			},
 			{
-				"name": "IS_LOW",
+				"name": "MF_IS_LOW",
 				"description": "Uses animations suitable for cars with a low ride-height."
 			},
 			{
-				"name": "IS_BIG",
+				"name": "MF_IS_BIG",
 				"description": "Changes the way that the AI drives around corners."
 			},
 			{
-				"name": "ABS_STD",
+				"name": "MF_ABS_STD",
 				"description": "Arcade Anti-Lock Braking System (ABS) equipped as standard; minimal slip allowed."
 			},
 			{
-				"name": "ABS_OPTION",
+				"name": "MF_ABS_OPTION",
 				"description": "Arcade Anti-Lock Braking System (ABS) equipped w/ brakes upgrade."
 			},
 			{
-				"name": "ABS_ALT_STD",
+				"name": "MF_ABS_ALT_STD",
 				"description": "Realistic Anti-Lock Braking System (ABS) equipped as standard; some slip allowed."
 			},
 			{
-				"name": "ABS_ALT_OPTION",
+				"name": "MF_ABS_ALT_OPTION",
 				"description": "Realistic Anti-Lock Braking System (ABS) equipped w/brakes upgrade."
 			},
 			{
-				"name": "NO_DOORS",
+				"name": "MF_NO_DOORS",
 				"description": "For vehicles that don't have any operable doors."
 			},
 			{
-				"name": "TANDEM_SEATS",
+				"name": "_MF_TANDEM_SEATS",
 				"description": "Two people will use the front passenger seat."
 			},
 			{
-				"name": "SIT_IN_BOAT",
+				"name": "MF_SIT_IN_BOAT",
 				"description": "Uses seated boat animation instead of standing."
 			},
 			{
-				"name": "HAS_TRACKS",
+				"name": "MF_HAS_TRACKS",
 				"description": "For vehicles with tracks instead of tires."
 			},
 			{
-				"name": "NO_EXHAUST",
+				"name": "MF_NO_EXHAUST",
 				"description": "Removes all exhaust particles."
 			},
 			{
-				"name": "DOUBLE_EXHAUST",
+				"name": "MF_DOUBLE_EXHAUST",
 				"description": "Creates a second exhaust by mirroring the model's exhaust over the y-axis."
 			},
 			{
-				"name": "NO1FPS_LOOK_BEHIND",
+				"name": "_MF_NO1FPS_LOOK_BEHIND",
 				"description": "Prevents player using rear view when in first-person mode."
 			},
 			{
-				"name": "CAN_ENTER_IF_NO_DOOR",
+				"name": "MF_CAN_ENTER_IF_NO_DOOR",
 				"description": "Allows entry into the vehicle despite no currently accessible doors."
 			},
 			{
-				"name": "AXLE_F_TORSION",
+				"name": "MF_AXLE_F_TORSION",
 				"description": "Front wheels stay vertical to the car."
 			},
 			{
-				"name": "AXLE_F_SOLID",
+				"name": "MF_AXLE_F_SOLID",
 				"description": "Front wheels stay parallel to each other."
 			},
 			{
-				"name": "AXLE_F_MCPHERSON",
+				"name": "MF_AXLE_F_MCPHERSON",
 				"description": "Front wheels can tilt."
 			},
 			{
-				"name": "ATTACH_PED_TO_BODYSHELL",
+				"name": "MF_ATTACH_PED_TO_BODYSHELL",
 				"description": "???"
 			},
 			{
-				"name": "AXLE_R_TORSION",
+				"name": "MF_AXLE_R_TORSION",
 				"description": "Rear wheels stay vertical to the car."
 			},
 			{
-				"name": "AXLE_R_SOLID",
+				"name": "MF_AXLE_R_SOLID",
 				"description": "Rear wheels stay parallel to each other."
 			},
 			{
-				"name": "AXLE_R_MCPHERSON",
+				"name": "MF_AXLE_R_MCPHERSON",
 				"description": "Rear wheels can tilt."
 			},
 			{
-				"name": "DONT_FORCE_GRND_CLEARANCE",
+				"name": "MF_DONT_FORCE_GRND_CLEARANCE",
 				"description": "Chassis COL is taken into account when suspension is compressed while hitting the ground, with sparks rendered."
 			},
 			{
-				"name": "DONT_RENDER_STEER",
+				"name": "MF_DONT_RENDER_STEER",
 				"description": "Does not render steering animations."
 			},
 			{
-				"name": "NO_WHEEL_BURST",
+				"name": "MF_NO_WHEEL_BURST",
 				"description": "Has Bulletproof Tires as standard."
 			},
 			{
-				"name": "INDESTRUCTIBLE",
+				"name": "MF_INDESTRUCTIBLE",
 				"description": "Can't explode or be considered inoperable from damage."
 			},
 			{
-				"name": "DOUBLE_FRONT_WHEELS",
+				"name": "MF_DOUBLE_FRONT_WHEELS",
 				"description": "Places a second instance of each front wheel next to the normal one."
 			},
 			{
-				"name": "RC",
-				"description": "For RC vehicles such as the RC Bandito and Invade & Persuade Tank."
+				"name": "MF_IS_RC",
+				"description": "For RC vehicles such as the RC Bandito and Invade & Persuade Tank. The player model is hidden upon entering the vehicle."
 			},
 			{
-				"name": "DOUBLE_RWHEELS",
+				"name": "MF_DOUBLE_REAR_WHEELS",
 				"description": "Duplicates the skidmarks of the rear tires."
 			},
 			{
@@ -126,96 +126,96 @@
 				"description": "Prevents wheel bones from detaching off the vehicle due to damage."
 			},
 			{
-				"name": "IS_HATCHBACK",
+				"name": "MF_IS_HATCHBACK",
 				"description": "Uses animations suitable for Trunk doors on hatchback-style vehicle bodies."
 			}
 		],
 		"strHandlingFlags": [{
-				"name": "SMOOTH_COMPRESN",
+				"name": "_HF_SMOOTH_COMPRESN",
 				"description": "Simulates progressive spring suspension. Makes suspension compression motion smoother."
 			},
 			{
-				"name": "REDUCED_MOD_MASS",
+				"name": "HF_REDUCED_MOD_MASS",
 				"description": "Reduces mass added from upgrades."
 			},
 			{
-				"name": "_DISABLE_HORN",
-				"description": "Disables horn. Used on vehicles with KERS."
+				"name": "HF_HAS_KERS",
+				"description": "Partially enables KERS on the vehicle; disables horn and shows the recharge bar below the minimap. KERS boost itself still needs to be enabled by the SET_VEHICLE_KERS_ALLOWED native."
 			},
 			{
-				"name": "OFFROAD_ABILITY3",
+				"name": "_HF_OFFROAD_ABILITY3",
 				"description": "Inverts the way grip works on the vehicle; with this flag enabled, grip starts at the fTractionCurveMin value and may increase up to the fTractionCurveMax value upon wheel slip. Grip stays at max beyond the vehicle's peak slip angle."
 			},
 			{
-				"name": "NO_HANDBRAKE",
+				"name": "HF_NO_HANDBRAKE",
 				"description": "Disables handbrake control for the vehicle."
 			},
 			{
-				"name": "STEER_REARWHEELS",
+				"name": "HF_STEER_REARWHEELS",
 				"description": "Steers the rear wheels instead of the front."
 			},
 			{
-				"name": "HB_REARWHEEL_STEER",
+				"name": "HF_HANDBRAKE_REARWHEELSTEER",
 				"description": "Handbrake control makes the rear wheels steer as well as the front."
 			},
 			{
-				"name": "STEER_ALL_WHEELS",
+				"name": "HF_STEER_ALL_WHEELS",
 				"description": "Steers all wheels, similar to 4-wheel-steering systems found on real vehicles. The rear wheels will steer at the same lock angle as the front, as defined by fSteeringLock."
 			},
 			{
-				"name": "FREEWHEEL_NO_GAS",
+				"name": "HF_FREEWHEEL_NO_GAS",
 				"description": "Disables engine-braking when no throttle is applied."
 			},
 			{
-				"name": "NO_REVERSE",
+				"name": "HF_NO_REVERSE",
 				"description": "Disables reversing for the vehicle."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_HF_UNKNOWN_10",
+				"description": "Unknown. Name hash: 0x4C11C7F9"
 			},
 			{
-				"name": "STEER_NO_WHEELS",
+				"name": "HF_STEER_NO_WHEELS",
 				"description": "Disables steering on all wheels, used with tracked vehicles."
 			},
 			{
-				"name": "CVT",
+				"name": "HF_CVT",
 				"description": "Gives the vehicle a fixed-ratio transmission with a gear ratio of 0.90, used for vehicles with nInitialDriveGears=1. If gears amount to more than 1, it will simply force the vehicle into top gear upon acceleration. Recommended for electric vehicles."
 			},
 			{
-				"name": "ALT_EXT_WHEEL_BOUNDS_BEH",
+				"name": "HF_ALT_EXT_WHEEL_BOUNDS_BEH",
 				"description": "???"
 			},
 			{
-				"name": "DONT_RAISE_BOUNDS_AT_SPEED",
+				"name": "HF_DONT_RAISE_BOUNDS_AT_SPEED",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "HF_EXT_WHEEL_BOUNDS_COL",
 				"description": "???"
 			},
 			{
-				"name": "LESS_SNOW_SINK",
+				"name": "HF_LESS_SNOW_SINK",
 				"description": "Less grip loss from deep mud/snow, most notably in North Yankton."
 			},
 			{
-				"name": "TYRES_CAN_CLI",
+				"name": "HF_TYRES_CAN_CLIP",
 				"description": "Tires are allowed to clip into the pavement when under enough pressure, effectiveness depends on tire sidewall. Generally makes the vehicle deal with uneven terrain better. Notes: this is the reason Offroad Tires improve performance on specific vehicles made by R*."
 			},
 			{
-				"name": "???",
+				"name": "_HF_UNKNOWN_19",
+				"description": "Unknown. name hash: 0x2DEA7A05"
+			},
+			{
+				"name": "HF_HEAVY_VEHICLE",
 				"description": "???"
 			},
 			{
-				"name": "HEAVY_VEHICLE",
-				"description": "???"
-			},
-			{
-				"name": "OFFROAD_ABILITY",
+				"name": "HF_OFFROAD_ABILITIES",
 				"description": "Scaled version of 00800000; similar effects, least power."
 			},
 			{
-				"name": "OFFROAD_ABILITY2",
+				"name": "HF_OFFROAD_ABILITIES_X2",
 				"description": "Scaled version of 00800000; similar effects, less power."
 			},
 			{
@@ -223,169 +223,169 @@
 				"description": "Includes the tires in the general side collision hitbox of the vehicle. Recommended for vehicles whose wheels extend beyond the bodywork, like monster-trucks."
 			},
 			{
-				"name": "INCREASED_GRAVITY",
+				"name": "_HF_INCREASED_GRAVITY",
 				"description": "Includes bush-collision immunity, flat grip increase proportional to slip angle/lateral velocity, increased vehicle gravity."
 			},
 			{
-				"name": "ENABLE_LEAN",
+				"name": "HF_ENABLE_LEAN",
 				"description": "??? Notes: Possibly for motorcycle leaning or boat leaning."
 			},
 			{
-				"name": "_ALLOW_MOTORCYCLE_TRACTION_LOSS",
+				"name": "_HF_ALLOW_MOTORCYCLE_TRACTION_LOSS",
 				"description": "Allows motorcycles to lose traction."
 			},
 			{
-				"name": "HEAVYARMOUR",
+				"name": "HF_HEAVYARMOUR",
 				"description": "???"
 			},
 			{
-				"name": "ARMOURED",
+				"name": "HF_ARMOURED",
+				"description": "Prevents vehicle doors (including hood and trunk) from opening in collisions."
+			},
+			{
+				"name": "HF_SELF_RIGHTING_IN_WATER",
 				"description": "???"
 			},
 			{
-				"name": "SELF_RIGHTING_IN_WATER",
+				"name": "HF_IMPROVED_RIGHTING_FORCE",
+				"description": "Adds extra force to the vehicle when attempting to flip it back on its wheels."
+			},
+			{
+				"name": "HF_USE_EXTRA_SOFT_SURFACE_SUS",
 				"description": "???"
 			},
 			{
-				"name": "IMPROVED_RIGHTING_FORCE",
-				"description": "???"
-			},
-			{
-				"name": "USE_EXTRA_SOFT_SURFACE_SUS",
-				"description": "???"
-			},
-			{
-				"name": "LAST_AVAILABLE_FLAG",
-				"description": "???"
+				"name": "HF_LAST_AVAILABLE_FLAG",
+				"description": "Most likely doesn't do anything."
 			}
 		],
 		"strAdvancedFlags": [{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_1",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_2",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_SMOOTH_REV_1ST_OLD",
+				"description": "Appears to be identical to the _AF_SMOOTH_REV_1ST flag used on the Swinger. Might need more looking into."
+			},
+			{
+				"name": "_AF_UNKNOWN_FLAG_4",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_5",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_6",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_7",
+				"description": "Unknown. Using this flag causes the vehicle's front wheels to wheelspin if the player is holding down the handbrake and forwards/backwards keys."
+			},
+			{
+				"name": "_AF_SMOOTH_HANDBRAKE",
+				"description": "Using the handbrake slows the car down more smoothly and, most of the time, without leaving tire marks."
+			},
+			{
+				"name": "_AF_UNKNOWN_FLAG_9",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_10",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_11",
+				"description": "Unknown. Possibly something to do with suspension, as using this flag in combination with _AF_HANDBRAKE_WHEELIE sometimes causes the vehicle's heading to reset to 0 while performing a wheelie."
+			},
+			{
+				"name": "_AF_UNKNOWN_FLAG_12",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_13",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_14",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_15",
 				"description": "???"
 			},
 			{
-				"name": "???",
+				"name": "_AF_UNKNOWN_FLAG_16",
 				"description": "???"
 			},
 			{
-				"name": "???",
-				"description": "???"
-			},
-			{
-				"name": "???",
-				"description": "???"
-			},
-			{
-				"name": "???",
-				"description": "???"
-			},
-			{
-				"name": "???",
-				"description": "???"
-			},
-			{
-				"name": "_TRACTION_CONTROL",
+				"name": "_AF_TRACTION_CONTROL",
 				"description": "Earlier upshifts, hard rev-limit per gear, low-speed traction control."
 			},
 			{
-				"name": "_HOLD_GEAR_LONGER",
+				"name": "_AF_HOLD_GEAR_LONGER",
 				"description": "Later upshifts; usually hits the gear's rev limit before shifting."
 			},
 			{
-				"name": "_STIFFER_SPRING_SPEED",
+				"name": "_AF_STIFFER_SPRING_SPEED",
 				"description": "Anti-downforce suspension; increases suspension spring force as vehicle goes faster."
 			},
 			{
-				"name": "_FAKE_WHEELSPIN",
+				"name": "_AF_FAKE_WHEELSPIN",
 				"description": "Generates fake wheelspin after an instance of real wheelspin; Tyres will stabilize and show 0.0m/s of slip with debugging data, but the traction behaves like it's still spinning."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_AF_REDUCED_RIGHTING_FORcE",
+				"description": "Reduces righting force of the vehicle, effectively making it much harder and slower to flip back on its wheels."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_AF_LONGER_1ST",
+				"description": "Extends the duration of the first gear, giving the vehicle a slower launch with greatly reduced wheelspin."
 			},
 			{
-				"name": "_SMOOTH_REV_1ST",
+				"name": "_AF_SMOOTH_REV_1ST",
 				"description": "Smooth first-gear revving; resistance to hitting the rev-limit."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_AF_NEUTRAL_STEER",
+				"description": "Allows the vehicle to be rotated left or right while parked on the spot. Intended for tanks/tracked vehicles."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_AF_HANDBRAKE_WHEELIE",
+				"description": "Allows the vehicle to perform a handbrake wheelie. The Muscle vehicle class is hardcoded to use this flag."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_AF_REDUCE_EXT_WHEEL_COL_CLIPPING",
+				"description": "Makes the wheels much less likely to clip into the ground when the vehicle is tipped over."
 			},
 			{
-				"name": "_IGNORE_TUNED_WHEELS_CLIP",
+				"name": "_AF_IGNORE_TUNED_WHEELS_CLIP",
 				"description": "Forced stock-tyre clipping boundaries, the sidewall gain/loss from a custom tyre will not matter. Refer to strHandlingFlags 00020000 above."
 			},
 			{
-				"name": "_DOWNFORCE_KERBFIX",
-				"description": "Changes the way Downforce and spoiler tuning works, uses the setup found on Open-Wheel class vehicles in the vanilla game. Each spoiler/bumper tuning has to be given some statistics. Adjusts initial downforce from fDownforceModifier. 'Curb - boosting' seems to be nullified."
+				"name": "_AF_DOWNFORCE_KERBFIX",
+				"description": "Changes the way Downforce and spoiler tuning works, uses the setup found on Open-Wheel class vehicles in the vanilla game. Each spoiler/bumper tuning has to be given AdvancedData values to affect downforce. Adjusts initial downforce from fDownforceModifier. 'Curb - boosting' seems to be nullified."
 			},
 			{
-				"name": "_DECREASE_BODYROLL_TUNING",
-				"description": "Reduces body-roll if suspension upgrades are equipped."
+				"name": "_AF_DECREASE_BODYROLL_TUNING",
+				"description": "Reduces body-roll if suspension upgrades are equipped. In addition, the vehicle gains more grip with each suspension option."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_AF_UNKNOWN_FLAG_30",
+				"description": "Likely non-existent as of b2245."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_AF_UNKNOWN_FLAG_31",
+				"description": "Likely non-existent as of b2245."
 			},
 			{
-				"name": "???",
-				"description": "???"
+				"name": "_AF_UNKNOWN_FLAG_32",
+				"description": "Likely non-existent as of b2245."
 			}
 		]
 	}

--- a/flags.json
+++ b/flags.json
@@ -259,6 +259,135 @@
 				"description": "Most likely doesn't do anything."
 			}
 		],
+		"strDamageFlags": [{
+				"name": "DF_DRIVER_SIDE_FRONT_DOOR",
+				"description": "Marks the driver-side front door (door_dside_f) bone as non-breakable."
+			},
+			{
+				"name": "DF_DRIVER_SIDE_REAR_DOOR",
+				"description": "Marks the driver-side rear door (door_dside_r) bone as non-breakable."
+			},
+			{
+				"name": "DF_DRIVER_PASSENGER_SIDE_FRONT_DOOR",
+				"description": "Marks the passenger-side front door (door_pside_f) bone as non-breakable."
+			},
+			{
+				"name": "DF_DRIVER_PASSENGER_SIDE_REAR_DOOR",
+				"description": "Marks the passenger-side rear door (door_pside_r) bone as non-breakable."
+			},
+			{
+				"name": "DF_BONNET",
+				"description": "Marks the bonnet bone as non-breakable."
+			},
+			{
+				"name": "DF_BOOT",
+				"description": "Marks the boot bone as non-breakable."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			},
+			{
+				"name": "N/A",
+				"description": "Flag does not exist."
+			}
+		],
 		"strAdvancedFlags": [{
 				"name": "_AF_UNKNOWN_FLAG_1",
 				"description": "???"
@@ -340,7 +469,7 @@
 				"description": "Generates fake wheelspin after an instance of real wheelspin; Tyres will stabilize and show 0.0m/s of slip with debugging data, but the traction behaves like it's still spinning."
 			},
 			{
-				"name": "_AF_REDUCED_RIGHTING_FORcE",
+				"name": "_AF_REDUCED_RIGHTING_FORCE",
 				"description": "Reduces righting force of the vehicle, effectively making it much harder and slower to flip back on its wheels."
 			},
 			{


### PR DESCRIPTION
All of the names (not prefixed with an underscore) are taken from RDR3, where the flags are strings rather than bitsets. Interestingly the last two HF_ flags are in RDR3 but it's unknown if they even exist in V, so someone must have been aware of the list of official names. Advanced Flag prefixes are just for naming consistency with the rest. It looks nicer and more uniform that way, as the pre-existing list of names did use the MF/HF prefixes for some flags.

Also added Advanced Flag information that I've been researching for a while. The pre-existing information sounds very specific, so if someone has researched those through the code I hope the same person could look into the first 16 flags. They seem to be doing something, but no car seems to use them and I could only see effects for 4 of them.

----

Somewhat unrelated, but I noticed that strDamageFlags are missing from this. They are:

- 1: `DF_DRIVER_SIDE_FRONT_DOOR`
- 2: `DF_DRIVER_SIDE_REAR_DOOR`
- 4: `DF_DRIVER_PASSENGER_SIDE_FRONT_DOOR`
- 8: `DF_DRIVER_PASSENGER_SIDE_REAR_DOOR`
- 10: `DF_BONNET`
- 20: `DF_BOOT`

Functions are self-explanatory. The door in the name is flagged as unbreakable.