### PR TITLE
added new b2545 flag+updated some unk descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ On file version increment, [Real Time Handling Editor](https://www.gta5-mods.com
 ### 2.3
 
 * Update flags `MF_TANDEM_SEATING`, `MF_NO_1STPERSON_LOOKBEHIND`, `HF_SMOOTHED_COMPRESSION`, `HF_HAS_TRACKS` by [alloc8or](https://github.com/alloc8or)
+
+### 2.4
+
+* Add `strAdvancedFlags` `_AF_HAS_SPECIAL_PERFORMANCE_MODS` from The Contract and add advanced flag research notes to `_AF_UNKNOWN_FLAG_1`, `_AF_UNKNOWN_FLAG_4`, `_AF_UNKNOWN_FLAG_11` by [Wildbrick142](https://github.com/Wildbrick142)

--- a/flags.json
+++ b/flags.json
@@ -1,5 +1,5 @@
 {
-	"version":"2.3",
+	"version":"2.4",
 	"flags": {
 		"strModelFlags": [{
 				"name": "MF_IS_VAN",
@@ -390,7 +390,7 @@
 		],
 		"strAdvancedFlags": [{
 				"name": "_AF_UNKNOWN_FLAG_1",
-				"description": "???"
+				"description": "Unknown. Has something to do with revs or gears, as the sounds rev up and momentarily pause when, tested on Issi Classic, driving in a circle."
 			},
 			{
 				"name": "_AF_UNKNOWN_FLAG_2",
@@ -402,7 +402,7 @@
 			},
 			{
 				"name": "_AF_UNKNOWN_FLAG_4",
-				"description": "???"
+				"description": "Unknown. Seems to have a similar effect to _AF_SMOOTH_REV_1ST, but with later upshifts."
 			},
 			{
 				"name": "_AF_UNKNOWN_FLAG_5",
@@ -430,7 +430,7 @@
 			},
 			{
 				"name": "_AF_UNKNOWN_FLAG_11",
-				"description": "Unknown. Possibly something to do with suspension, as using this flag in combination with _AF_HANDBRAKE_WHEELIE sometimes causes the vehicle's heading to reset to 0 while performing a wheelie."
+				"description": "Unknown. Sets the clutch value to 0.0 when idling."
 			},
 			{
 				"name": "_AF_UNKNOWN_FLAG_12",
@@ -505,16 +505,16 @@
 				"description": "Reduces body-roll if suspension upgrades are equipped. In addition, the vehicle gains more grip with each suspension option."
 			},
 			{
-				"name": "_AF_UNKNOWN_FLAG_30",
-				"description": "Likely non-existent as of b2372."
+				"name": "_AF_HAS_SPECIAL_PERFORMANCE_MODS",
+				"description": "Requires AdvancedData to work. Adds Turbo-affecting mods for mod slot 20 (VMT_KNOB) parts, and power-affecting mods for mod slot 22 (VMT_ICE) parts."
 			},
 			{
 				"name": "_AF_UNKNOWN_FLAG_31",
-				"description": "Likely non-existent as of b2372."
+				"description": "Likely non-existent as of b2545."
 			},
 			{
 				"name": "_AF_UNKNOWN_FLAG_32",
-				"description": "Likely non-existent as of b2372."
+				"description": "Likely non-existent as of b2545."
 			}
 		]
 	}


### PR DESCRIPTION
Updated descriptions for
- `_AF_UNKNOWN_FLAG_1`
- `_AF_UNKNOWN_FLAG_4`
- `_AF_UNKNOWN_FLAG_11`

with observed effects. Hopefully they can help those more knowledgeable to pinpoint the exact effects.


Added `_AF_HAS_SPECIAL_PERFORMANCE_MODS`, replacing `_AF_UNKNOWN_FLAG_30`, which has been added to the game as of b2545. It's used to add extra performance parts that increase the car's power, and add extra upgrades to turbo - see [here](https://twitter.com/WildBrick142/status/1471441974746091523) for more details.